### PR TITLE
feat: add row selection support to tables, update styles for selected…

### DIFF
--- a/src/main/frontend/src/components/BrIrpfTable.tsx
+++ b/src/main/frontend/src/components/BrIrpfTable.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { BR_IRPF_COLUMN_HEADERS, type IrpfAssetData, type IrpfResponse } from '../api/types'
 
 interface BrIrpfTableProps {
@@ -10,6 +11,8 @@ const brlFormatter = new Intl.NumberFormat('pt-BR', {
 })
 
 export function BrIrpfTable({ data }: BrIrpfTableProps) {
+  const [selectedKey, setSelectedKey] = useState<string | null>(null)
+
   if (data.length === 0) {
     return <p>Nenhum dado encontrado.</p>
   }
@@ -25,17 +28,28 @@ export function BrIrpfTable({ data }: BrIrpfTableProps) {
       </thead>
       <tbody>
         {data.map((row) => (
-          <BrIrpfRow key={row.symbol} row={row} />
+          <BrIrpfRow
+            key={row.symbol}
+            row={row}
+            selected={selectedKey === row.symbol}
+            onSelect={() => setSelectedKey(selectedKey === row.symbol ? null : row.symbol)}
+          />
         ))}
       </tbody>
     </table>
   )
 }
 
-function BrIrpfRow({ row }: { row: IrpfAssetData }) {
+interface BrIrpfRowProps {
+  readonly row: IrpfAssetData
+  readonly selected: boolean
+  readonly onSelect: () => void
+}
+
+function BrIrpfRow({ row, selected, onSelect }: BrIrpfRowProps) {
   if (row.error) {
     return (
-      <tr className="irpf-error-row">
+      <tr className={`irpf-error-row${selected ? ' selected' : ''}`} onClick={onSelect}>
         <td>{row.symbol}</td>
         <td colSpan={9}>
           <details className="irpf-error-details">
@@ -48,7 +62,7 @@ function BrIrpfRow({ row }: { row: IrpfAssetData }) {
   }
 
   return (
-    <tr>
+    <tr className={selected ? 'selected' : undefined} onClick={onSelect}>
       <td>{row.symbol}</td>
       <td>{row.quantity}</td>
       <td>{brlFormatter.format(row.avgCostBrl!)}</td>

--- a/src/main/frontend/src/components/IrpfTable.tsx
+++ b/src/main/frontend/src/components/IrpfTable.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { IRPF_COLUMN_HEADERS, type IrpfAssetData, type IrpfResponse } from '../api/types'
 
 interface IrpfTableProps {
@@ -20,6 +21,8 @@ const ptaxFormatter = new Intl.NumberFormat('pt-BR', {
 })
 
 export function IrpfTable({ data }: IrpfTableProps) {
+  const [selectedKey, setSelectedKey] = useState<string | null>(null)
+
   if (data.length === 0) {
     return <p>Nenhum dado encontrado.</p>
   }
@@ -35,17 +38,28 @@ export function IrpfTable({ data }: IrpfTableProps) {
       </thead>
       <tbody>
         {data.map((row) => (
-          <IrpfRow key={row.symbol} row={row} />
+          <IrpfRow
+            key={row.symbol}
+            row={row}
+            selected={selectedKey === row.symbol}
+            onSelect={() => setSelectedKey(selectedKey === row.symbol ? null : row.symbol)}
+          />
         ))}
       </tbody>
     </table>
   )
 }
 
-function IrpfRow({ row }: { readonly row: IrpfAssetData }) {
+interface IrpfRowProps {
+  readonly row: IrpfAssetData
+  readonly selected: boolean
+  readonly onSelect: () => void
+}
+
+function IrpfRow({ row, selected, onSelect }: IrpfRowProps) {
   if (row.error) {
     return (
-      <tr className="irpf-error-row">
+      <tr className={`irpf-error-row${selected ? ' selected' : ''}`} onClick={onSelect}>
         <td>{row.symbol}</td>
         <td colSpan={10}>
           <details className="irpf-error-details">
@@ -58,7 +72,7 @@ function IrpfRow({ row }: { readonly row: IrpfAssetData }) {
   }
 
   return (
-    <tr>
+    <tr className={selected ? 'selected' : undefined} onClick={onSelect}>
       <td>{row.symbol}</td>
       <td>{row.quantity}</td>
       <td>{usdFormatter.format(row.avgCostUsd!)}</td>

--- a/src/main/frontend/src/components/StockTable.tsx
+++ b/src/main/frontend/src/components/StockTable.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { COLUMN_HEADERS, type StocksResponse } from '../api/types'
 
 interface StockTableProps {
@@ -5,6 +6,8 @@ interface StockTableProps {
 }
 
 export function StockTable({ data }: StockTableProps) {
+  const [selectedKey, setSelectedKey] = useState<string | null>(null)
+
   if (data.length === 0) {
     return <p>Nenhum ativo encontrado.</p>
   }
@@ -20,7 +23,11 @@ export function StockTable({ data }: StockTableProps) {
       </thead>
       <tbody>
         {data.map((row) => (
-          <tr key={row[0]}>
+          <tr
+            key={row[0]}
+            className={selectedKey === row[0] ? 'selected' : undefined}
+            onClick={() => setSelectedKey(selectedKey === row[0] ? null : row[0])}
+          >
             {row.map((cell, i) => (
               <td key={`${row[0]}-${i}`}>{cell}</td>
             ))}

--- a/src/main/frontend/src/index.css
+++ b/src/main/frontend/src/index.css
@@ -119,6 +119,10 @@ tr:hover td {
   background: #fafafa;
 }
 
+tr.selected td {
+  background: #e8f0fe;
+}
+
 .irpf-controls {
   margin-bottom: 1rem;
   display: flex;


### PR DESCRIPTION
… rows

- Added `useState` to handle row selection in `BrIrpfTable`, `IrpfTable`, and `StockTable` components.
- Modified `Row` components to include `selected` and `onSelect` props, enabling click-to-select functionality.
- Updated `index.css` with new styles for selected rows (`tr.selected td`).